### PR TITLE
Update start_yabasanshiro.sh

### DIFF
--- a/packages/emulators/standalone/yabasanshiro-sa/scripts/start_yabasanshiro.sh
+++ b/packages/emulators/standalone/yabasanshiro-sa/scripts/start_yabasanshiro.sh
@@ -37,7 +37,12 @@ fi
 if [ ! -e "${CONFIG_DIR}/input.cfg" ]
 then
   rm -f ${CONFIG_DIR}/keymapv2.json
-  GAMEPAD="'$(grep -b4 js0 /proc/bus/input/devices | awk 'BEGIN {FS="\""}; /Name/ {printf $2}')'"
+  # Check for js0, else fall back to joypad
+  if grep -q "js0" /proc/bus/input/devices; then
+    GAMEPAD=$(grep -b4 js0 /proc/bus/input/devices | awk 'BEGIN {FS="\""}; /Name/ {printf $2}')
+  else
+    GAMEPAD=$(grep -b4 joypad /proc/bus/input/devices | awk 'BEGIN {FS="\""}; /Name/ {printf $2}')
+  fi
   GAMEPADCONFIG=$(xmlstarlet sel -t -c "//inputList/inputConfig[@deviceName=${GAMEPAD}]" -n /storage/.emulationstation/es_input.cfg)
 
   MAPPING_FILE="/usr/config/yabasanshiro/devices/keymapv2_$(eval echo $GAMEPAD).json"


### PR DESCRIPTION
Fixes undeclared GAMEPAD where js0 does not exist. On H700 devices it is called joypad and not js0.

`cat /proc/bus/input/devices`

Output:
```
I: Bus=0000 Vendor=0000 Product=0000 Version=0000
N: Name="axp20x-pek"
P: Phys=m1kbd/input2
S: Sysfs=/devices/platform/soc/7081400.i2c/i2c-0/0-0034/axp20x-pek/input/input0
U: Uniq=
H: Handlers=kbd event0
B: PROP=0
B: EV=3
B: KEY=10000000000000 0

I: Bus=0000 Vendor=0000 Product=0000 Version=0000
N: Name="h616-audio-codec Headphone Jack"
P: Phys=ALSA
S: Sysfs=/devices/platform/soc/5096000.codec/sound/card0/input1
U: Uniq=
H: Handlers=event1
B: PROP=0
B: EV=21
B: SW=4

I: Bus=0019 Vendor=0001 Product=0001 Version=0100
N: Name="gpio-keys-volume"
P: Phys=gpio-keys/input0
S: Sysfs=/devices/platform/gpio-keys-volume/input/input2
U: Uniq=
H: Handlers=kbd event2
B: PROP=0
B: EV=100003
B: KEY=c000000000000 0

I: Bus=0019 Vendor=484b Product=14df Version=0100
N: Name="H700 Gamepad"
P: Phys=rocknix-singleadc-joypad/input0
S: Sysfs=/devices/platform/rocknix-singleadc-joypad/input/input3
U: Uniq=
H: Handlers=event3
B: PROP=0
B: EV=20000b
B: KEY=f00000000 0 0 0 7fdb000000000000 0 0 0 0
B: ABS=1b
B: FF=107030000 0
```